### PR TITLE
Update rectify_cuda.cu

### DIFF
--- a/rfconv/lib/rectify_cuda.cu
+++ b/rfconv/lib/rectify_cuda.cu
@@ -47,7 +47,7 @@ __global__ void conv_rectify_cuda_frame(
     else {
       mul_factor = accscalar_t(1.0) * pool_size / (hcount * wcount);
     }
-    top_data[index] = ScalarConvert<accscalar_t, scalar_t>::to(top_data[index] * mul_factor);
+    top_data[index] = static_cast<scalar_t>(top_data[index] * mul_factor);
   }
 }
 


### PR DESCRIPTION
in short  : Remove THC ScalarConvert


Why this PR requires?
-----------
I'm not sure which library/language update caused the install to fail, but I can't build C++ right now.

How to solve ?
------------
Remove `ScalarConvert` of `THC/THCNumerics.cuh`  and replace to `static_cast`

```
	Error
		RuntimeError
		---------------------------------------------------------------------------
		CalledProcessError                        Traceback (most recent call last)
		/usr/local/lib/python3.7/dist-packages/torch/utils/cpp_extension.py in _run_ninja_build(build_directory, verbose, error_prefix)
		   1745             check=True,
		-> 1746             env=env)
		   1747     except subprocess.CalledProcessError as e:
		
		/usr/lib/python3.7/subprocess.py in run(input, capture_output, timeout, check, *popenargs, **kwargs)
		    511             raise CalledProcessError(retcode, process.args,
		--> 512                                      output=stdout, stderr=stderr)
		    513     return CompletedProcess(process.args, retcode, stdout, stderr)
		
		CalledProcessError: Command '['ninja', '-v']' returned non-zero exit status 1.
		
		The above exception was the direct cause of the following exception:
		
		RuntimeError                              Traceback (most recent call last)
		<ipython-input-1-4dcd4c97c80c> in <module>()
		      1 
		----> 2 from rfconv import RFConv2d
		
		/usr/local/lib/python3.7/dist-packages/rfconv/__init__.py in <module>()
		----> 1 from .nn import RFConv2d
		
		/usr/local/lib/python3.7/dist-packages/rfconv/nn.py in <module>()
		     15 from torch.nn.modules.utils import _pair
		     16 
		---> 17 from .function import rectify
		     18 
		     19 __all__ = ['RFConv2d']
		
		/usr/local/lib/python3.7/dist-packages/rfconv/function.py in <module>()
		     11 from torch.autograd import Function
		     12 
		---> 13 from . import lib
		     14 
		     15 __all__ = ['rectify']
		
		/usr/local/lib/python3.7/dist-packages/rfconv/lib/__init__.py in <module>()
		     15             os.path.join(cwd, 'rectify_cuda.cu'),
		     16         ], extra_cuda_cflags=["--expt-extended-lambda"],
		---> 17         build_directory=cwd, verbose=False)
		
		/usr/local/lib/python3.7/dist-packages/torch/utils/cpp_extension.py in load(name, sources, extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths, build_directory, verbose, with_cuda, is_python_module, is_standalone, keep_intermediates)
		   1154         is_python_module,
		   1155         is_standalone,
		-> 1156         keep_intermediates=keep_intermediates)
		   1157 
		   1158 
		
		/usr/local/lib/python3.7/dist-packages/torch/utils/cpp_extension.py in _jit_compile(name, sources, extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths, build_directory, verbose, with_cuda, is_python_module, is_standalone, keep_intermediates)
		   1365                         verbose=verbose,
		   1366                         with_cuda=with_cuda,
		-> 1367                         is_standalone=is_standalone)
		   1368             finally:
		   1369                 baton.release()
		
		/usr/local/lib/python3.7/dist-packages/torch/utils/cpp_extension.py in _write_ninja_file_and_build_library(name, sources, extra_cflags, extra_cuda_cflags, extra_ldflags, extra_include_paths, build_directory, verbose, with_cuda, is_standalone)
		   1470         build_directory,
		   1471         verbose,
		-> 1472         error_prefix=f"Error building extension '{name}'")
		   1473 
		   1474 
		
		/usr/local/lib/python3.7/dist-packages/torch/utils/cpp_extension.py in _run_ninja_build(build_directory, verbose, error_prefix)
		   1754         if hasattr(error, 'output') and error.output:  # type: ignore[union-attr]
		   1755             message += f": {error.output.decode(*SUBPROCESS_DECODE_ARGS)}"  # type: ignore[union-attr]
		-> 1756         raise RuntimeError(message) from e
		   1757 
		   1758 
		
		RuntimeError: Error building extension 'enclib_gpu': [1/3] /usr/local/cuda/bin/nvcc  -DTORCH_EXTENSION_NAME=enclib_gpu -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -isystem /usr/local/lib/python3.7/dist-packages/torch/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/torch/csrc/api/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/TH -isystem /usr/local/lib/python3.7/dist-packages/torch/include/THC -isystem /usr/local/cuda/include -isystem /usr/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_70,code=compute_70 -gencode=arch=compute_70,code=sm_70 --compiler-options '-fPIC' --expt-extended-lambda -std=c++14 -c /usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu -o rectify_cuda.cuda.o 
		FAILED: rectify_cuda.cuda.o 
		/usr/local/cuda/bin/nvcc  -DTORCH_EXTENSION_NAME=enclib_gpu -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -isystem /usr/local/lib/python3.7/dist-packages/torch/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/torch/csrc/api/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/TH -isystem /usr/local/lib/python3.7/dist-packages/torch/include/THC -isystem /usr/local/cuda/include -isystem /usr/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr -gencode=arch=compute_70,code=compute_70 -gencode=arch=compute_70,code=sm_70 --compiler-options '-fPIC' --expt-extended-lambda -std=c++14 -c /usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu -o rectify_cuda.cuda.o 
		/usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu(50): error: identifier "ScalarConvert" is undefined
		
		/usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu(50): error: type name is not allowed
		
		/usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu(50): error: type name is not allowed
		
		/usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu(50): error: the global scope has no "to"
		
		4 errors detected in the compilation of "/usr/local/lib/python3.7/dist-packages/rfconv/lib/rectify_cuda.cu".
		[2/3] c++ -MMD -MF operator_cuda.o.d -DTORCH_EXTENSION_NAME=enclib_gpu -DTORCH_API_INCLUDE_EXTENSION_H -DPYBIND11_COMPILER_TYPE=\"_gcc\" -DPYBIND11_STDLIB=\"_libstdcpp\" -DPYBIND11_BUILD_ABI=\"_cxxabi1011\" -isystem /usr/local/lib/python3.7/dist-packages/torch/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/torch/csrc/api/include -isystem /usr/local/lib/python3.7/dist-packages/torch/include/TH -isystem /usr/local/lib/python3.7/dist-packages/torch/include/THC -isystem /usr/local/cuda/include -isystem /usr/include/python3.7m -D_GLIBCXX_USE_CXX11_ABI=0 -fPIC -std=c++14 -c /usr/local/lib/python3.7/dist-packages/rfconv/lib/operator_cuda.cpp -o operator_cuda.o 
		ninja: build stopped: subcommand failed.
		
```

in colab, python 3.7

I can't import the module.

also fail on build from source (repo)

And... voila! I succeeded by removing `ScalarConvert`